### PR TITLE
perf: optimize comparator (2.87x)

### DIFF
--- a/codeflash/verification/comparator.py
+++ b/codeflash/verification/comparator.py
@@ -223,7 +223,37 @@ def comparator(orig: Any, new: Any, superset_obj: bool = False) -> bool:
         if orig_type is list or orig_type is tuple:
             if len(orig) != len(new):
                 return False
-            return all(comparator(elem1, elem2, superset_obj) for elem1, elem2 in zip(orig, new))
+            for elem1, elem2 in zip(orig, new):
+                if elem1 is elem2:
+                    continue
+                e1_type = type(elem1)
+                if e1_type is not type(elem2):
+                    if not comparator(elem1, elem2, superset_obj):
+                        return False
+                    continue
+                if e1_type is int or e1_type is bool or e1_type is type(None):
+                    if elem1 != elem2:
+                        return False
+                elif e1_type is str:
+                    if elem1 != elem2:
+                        if not (
+                            _is_temp_path(elem1)
+                            and _is_temp_path(elem2)
+                            and _normalize_temp_path(elem1) == _normalize_temp_path(elem2)
+                        ):
+                            return False
+                elif e1_type is float:
+                    if not (elem1 == elem2 or (math.isnan(elem1) and math.isnan(elem2)) or math.isclose(elem1, elem2)):
+                        return False
+                elif e1_type is list or e1_type is tuple or e1_type is dict:
+                    if not comparator(elem1, elem2, superset_obj):
+                        return False
+                elif e1_type in _IDENTITY_EQ_TYPES:
+                    if elem1 != elem2:
+                        return False
+                elif not comparator(elem1, elem2, superset_obj):
+                    return False
+            return True
         if orig_type is dict:
             if superset_obj:
                 return all(k in new and comparator(v, new[k], superset_obj) for k, v in orig.items())


### PR DESCRIPTION
Part of the optimization stack — see umbrella PR #TBD.

Optimizes `comparator` in `codeflash/verification/comparator.py`.

---

Replaced generator expression with inline loop for list/tuple comparison. Added type-specific fast paths (int/bool/None/str/float) directly in the loop to avoid recursive function call overhead for primitive elements.

## Benchmark

### **Python**: 3.12.3 | **Requires-Python**: >=3.9

| Metric | Before | After |
|---|---|---|
| CPU time | 0.0005s | 0.0002s |

### Interaction with other PRs

function_call_elimination

## Changes

- `codeflash/verification/comparator.py`

<details>
<summary><b>Reproduce the benchmark locally</b></summary>

```bash
pip install "codeflash @ git+https://github.com/codeflash-ai/codeflash.git@main"
codeflash compare main codeflash/perf/comparator
```

</details>

## Test plan

- [x] 223 tests pass
- [x] Linter clean
- [x] Benchmarked: 2.87x

---

*Generated by [codeflash](https://www.codeflash.ai) optimization agent*
