### PR TITLE
perf: optimize path_belongs_to_site_packages (151x)

### DIFF
--- a/codeflash/code_utils/code_utils.py
+++ b/codeflash/code_utils/code_utils.py
@@ -427,10 +427,20 @@ def get_run_tmp_file(file_path: Path | str) -> Path:
     return get_run_tmp_file.tmpdir_path / file_path
 
 
+_RESOLVED_SITE_PACKAGES: tuple[Path, ...] | None = None
+
+
+def _get_resolved_site_packages() -> tuple[Path, ...]:
+    global _RESOLVED_SITE_PACKAGES
+    if _RESOLVED_SITE_PACKAGES is None:
+        _RESOLVED_SITE_PACKAGES = tuple(Path(p).resolve() for p in site.getsitepackages())
+    return _RESOLVED_SITE_PACKAGES
+
+
+@lru_cache(maxsize=4096)
 def path_belongs_to_site_packages(file_path: Path) -> bool:
     file_path_resolved = file_path.resolve()
-    site_packages = [Path(p).resolve() for p in site.getsitepackages()]
-    return any(file_path_resolved.is_relative_to(site_package_path) for site_package_path in site_packages)
+    return any(file_path_resolved.is_relative_to(sp) for sp in _get_resolved_site_packages())
 
 
 def is_class_defined_in_file(class_name: str, file_path: Path) -> bool:


### PR DESCRIPTION
Part of the optimization stack — see umbrella PR #TBD.

Optimizes `path_belongs_to_site_packages` in `codeflash/code_utils/code_utils.py`.

---

Added lru_cache(maxsize=4096) and module-level resolved site packages cache to avoid repeated Path.resolve() and is_relative_to() calls across 5250 invocations

## Benchmark

### **Python**: 3.12.3 | **Requires-Python**: >=3.9

| Metric | Before | After |
|---|---|---|
| CPU time | 4.7000s | 0.0310s |

### Interaction with other PRs

filesystem_caching

## Changes

- `codeflash/code_utils/code_utils.py`

<details>
<summary><b>Reproduce the benchmark locally</b></summary>

```bash
pip install "codeflash @ git+https://github.com/codeflash-ai/codeflash.git@main"
codeflash compare main codeflash/perf/path_belongs_to_site_packages
```

</details>

## Test plan

- [x] 47 tests pass
- [x] Linter clean
- [x] Benchmarked: 151x

---

*Generated by [codeflash](https://www.codeflash.ai) optimization agent*
